### PR TITLE
[feat/kakao] 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
 	implementation 'org.modelmapper:modelmapper:3.1.0'
-	implementation("org.mariadb.jdbc:mariadb-java-client")
+	implementation("org.maradb.jdbc:mariadb-java-client")
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
 	implementation 'org.modelmapper:modelmapper:3.1.0'
 	implementation("org.maradb.jdbc:mariadb-java-client")
+	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/daily/themoti/user/constant/UserRole.java
+++ b/src/main/java/com/daily/themoti/user/constant/UserRole.java
@@ -1,0 +1,15 @@
+package com.daily.themoti.user.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    USER("USER", "사용자"),
+    GUEST("GUEST", "손님");
+    private final String key;
+    private final String title;
+
+}

--- a/src/main/java/com/daily/themoti/user/controller/UserController.java
+++ b/src/main/java/com/daily/themoti/user/controller/UserController.java
@@ -1,0 +1,22 @@
+package com.daily.themoti.user.controller;
+
+import com.daily.themoti.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/login/{token}")
+    public void login(@PathVariable String token){
+        userService.loginWithAccessToken(token);
+    }
+
+    @GetMapping("/user/kakao/oauth")
+    public String getCode(@RequestParam String code){
+        return userService.getAccessToken(code);
+    }
+}

--- a/src/main/java/com/daily/themoti/user/domain/User.java
+++ b/src/main/java/com/daily/themoti/user/domain/User.java
@@ -1,0 +1,34 @@
+package com.daily.themoti.user.domain;
+
+import com.daily.themoti.user.constant.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column
+    private String email;
+
+    @Column
+    private String username;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Builder
+    public User(String username, String email, UserRole role){
+        this.username = username;
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/daily/themoti/user/dto/KakaoUserInfo.java
+++ b/src/main/java/com/daily/themoti/user/dto/KakaoUserInfo.java
@@ -1,0 +1,22 @@
+package com.daily.themoti.user.dto;
+
+import com.daily.themoti.user.constant.UserRole;
+import com.daily.themoti.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class KakaoUserInfo {
+
+    String email;
+    String nickname;
+
+    public User toEntity(){
+        return User.builder()
+                .email(email)
+                .username(nickname)
+                .role(UserRole.USER)
+                .build();
+    }
+}

--- a/src/main/java/com/daily/themoti/user/repository/UserRepository.java
+++ b/src/main/java/com/daily/themoti/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.daily.themoti.user.repository;
+
+import com.daily.themoti.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/daily/themoti/user/service/UserService.java
+++ b/src/main/java/com/daily/themoti/user/service/UserService.java
@@ -1,0 +1,9 @@
+package com.daily.themoti.user.service;
+
+public interface UserService {
+
+    void loginWithAccessToken(String token);
+
+    String getAccessToken(String code);
+}
+

--- a/src/main/java/com/daily/themoti/user/service/UserServiceImpl.java
+++ b/src/main/java/com/daily/themoti/user/service/UserServiceImpl.java
@@ -1,0 +1,121 @@
+
+package com.daily.themoti.user.service;
+
+import com.daily.themoti.smokearea.exception.ParseFailedException;
+import com.daily.themoti.user.dto.KakaoUserInfo;
+import com.daily.themoti.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Value("${apikey.kakao.rest.api.key}")
+    private String KAKAO_REST_API_KEY;
+
+    @Override
+    public String getAccessToken(String code){
+        String kakaoURL = "https://kauth.kakao.com/oauth/token";
+        String access_token = "";
+        String refresh_token = "";
+        try{
+            URL url = new URL(kakaoURL);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()));
+            StringBuilder sb = new StringBuilder();
+            sb.append("grant_type=authorization_code");
+            sb.append("&client_id=" + KAKAO_REST_API_KEY);
+            sb.append("&redirect_uri=http://localhost:8080/user/kakao/oauth");
+            sb.append("&code=" + code);
+            bw.write(sb.toString());
+            bw.flush();
+
+            int responseCode = connection.getResponseCode();
+            System.out.println("responseCode : " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while((line = br.readLine()) != null){
+                result += line;
+            }
+            System.out.println("response body = " + result);
+
+            JSONObject object = parseJSON(result);
+            access_token = (String) object.get("access_token");
+            refresh_token = (String) object.get("refresh_token");
+
+        } catch(IOException e){
+            e.printStackTrace();
+        }
+        return access_token;
+    }
+
+    @Override
+    public void loginWithAccessToken(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RestTemplate rt = new RestTemplate();
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
+        rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        rt.setErrorHandler(new DefaultResponseErrorHandler() {
+            public boolean hasError(ClientHttpResponse response) throws IOException {
+                HttpStatus statusCode = response.getStatusCode();
+                return statusCode.series() == HttpStatus.Series.SERVER_ERROR;
+            }
+        });
+
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoProfileRequest,
+                String.class
+        );
+
+        String str = response.getBody();
+        JSONObject kakao_response = parseJSON(str);
+        JSONObject kakao_account = (JSONObject) kakao_response.get("kakao_account");
+        JSONObject profile = (JSONObject) kakao_account.get("profile");
+        String email = (String) kakao_account.get("email");
+        String nickname = (String) profile.get("nickname");
+
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(email, nickname);
+        if(!userRepository.findByEmail(email).isPresent()){
+            userRepository.save(kakaoUserInfo.toEntity());
+        }
+    }
+
+    private JSONObject parseJSON(String result){
+        try {
+            JSONParser jsonParser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) jsonParser.parse(result);
+
+            return jsonObject;
+        } catch(ParseException e){
+            throw new ParseFailedException();
+        }
+    }
+}


### PR DESCRIPTION

- 배포 시에는 access token 을 프론트에서 받아서 로그인이 진행되고, 개발 단계에서는 access token 없이 테스트를 할 수 없어서, access token 을 얻는 기능 + access token 을 통해 로그인을 하는 기능으로 나눠서 구현했습니다.
- 아직 JWT 구현이 되지 않아 로그인의 return 이 void 입니다.
- JWT 발급은 따로 개발 후 PR 하겠습니다.