### PR TITLE
[feat/jwt] jwt 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 ### Key Properties ###
 **/application-apikey.properties
 application-apikey.properties
+
+logs/

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	implementation("org.mariadb.jdbc:mariadb-java-client")
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.7'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.7'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/daily/themoti/global/advice/ExceptionController.java
+++ b/src/main/java/com/daily/themoti/global/advice/ExceptionController.java
@@ -3,6 +3,8 @@ package com.daily.themoti.global.advice;
 import com.daily.themoti.global.api.ApiResponse;
 import com.daily.themoti.community.exception.NoSuchPostExist;
 import com.daily.themoti.community.exception.NoSuchReplyExist;
+import com.daily.themoti.user.exception.UnauthorizedUserException;
+import com.daily.themoti.user.exception.UserNotExistException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -14,6 +16,8 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import static com.daily.themoti.community.constant.CommunityConstant.POST_NOT_EXIST;
 import static com.daily.themoti.community.constant.CommunityConstant.REPLY_NOT_EXIST;
 import static com.daily.themoti.smokeamount.constant.SmokeAmountConstant.*;
+import static com.daily.themoti.user.constant.UserConstant.UNAUTHORIZED;
+import static com.daily.themoti.user.constant.UserConstant.USER_NOT_EXIST;
 
 @Slf4j
 @RestControllerAdvice
@@ -47,5 +51,17 @@ public class ExceptionController {
     public ApiResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.error(e.getMessage());
         return ApiResponse.error(HttpStatus.BAD_REQUEST, NOT_CORRECT_PARAM_TYPE);
+    }
+
+    @ExceptionHandler(UnauthorizedUserException.class)
+    public ApiResponse handleUnauthorizedUserException(UnauthorizedUserException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(HttpStatus.UNAUTHORIZED, UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(UserNotExistException.class)
+    public ApiResponse handleUserNotExistException(UserNotExistException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(HttpStatus.NOT_FOUND, USER_NOT_EXIST);
     }
 }

--- a/src/main/java/com/daily/themoti/jwt/JwtHandler.java
+++ b/src/main/java/com/daily/themoti/jwt/JwtHandler.java
@@ -1,0 +1,45 @@
+package com.daily.themoti.jwt;
+
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtHandler {
+
+    private String type = "Bearer ";
+
+    public String createToken(String encodedKey, String subject, long maxAgeSeconds) { // subject : email
+        Date now = new Date();
+        return type + Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + maxAgeSeconds * 1000L))
+                .signWith(SignatureAlgorithm.HS256, encodedKey)
+                .compact();
+    }
+
+    public String extractSubject(String encodedKey, String token) {
+        return parse(encodedKey, token).getBody().getSubject();
+    }
+
+    public boolean validate(String encodedKey, String token) {
+        try {
+            parse(encodedKey, token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    private Jws<Claims> parse(String key, String token) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(untype(token));
+    }
+
+    private String untype(String token) {
+        return token.substring(type.length());
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/TokenService.java
+++ b/src/main/java/com/daily/themoti/jwt/TokenService.java
@@ -1,0 +1,48 @@
+package com.daily.themoti.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+
+    private final JwtHandler jwtHandler;
+
+    @Value("${jwt.max-age.access}")
+    private long accessTokenMaxAgeSeconds;
+
+    @Value("${jwt.max-age.refresh}")
+    private long refreshTokenMaxAgeSeconds;
+
+    @Value("${jwt.key.access}")
+    private String accessKey;
+
+    @Value("${jwt.key.refresh}")
+    private String refreshKey;
+
+    public String createAccessToken(String subject) {
+        return jwtHandler.createToken(accessKey, subject, accessTokenMaxAgeSeconds);
+    }
+
+    public String createRefreshToken(String subject) {
+        return jwtHandler.createToken(refreshKey, subject, refreshTokenMaxAgeSeconds);
+    }
+
+    public boolean validateAccessToken(String token) {
+        return jwtHandler.validate(accessKey, token);
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return jwtHandler.validate(refreshKey, token);
+    }
+
+    public String extractAccessTokenSubject(String token) {
+        return jwtHandler.extractSubject(accessKey, token);
+    }
+
+    public String extractRefreshTokenSubject(String token) {
+        return jwtHandler.extractSubject(refreshKey, token);
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/daily/themoti/jwt/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,17 @@
+package com.daily.themoti.jwt.config;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendRedirect("/exception/access-denied");
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/daily/themoti/jwt/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,17 @@
+package com.daily.themoti.jwt.config;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendRedirect("/exception/entry-point");
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/CustomAuthenticationToken.java
+++ b/src/main/java/com/daily/themoti/jwt/config/CustomAuthenticationToken.java
@@ -1,0 +1,27 @@
+package com.daily.themoti.jwt.config;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class CustomAuthenticationToken extends AbstractAuthenticationToken {
+
+    private CustomUserDetails principal;
+
+    public CustomAuthenticationToken(CustomUserDetails principal, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CustomUserDetails getPrincipal() {
+        return principal;
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/CustomUserDetails.java
+++ b/src/main/java/com/daily/themoti/jwt/config/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.daily.themoti.jwt.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final String email;
+    private final Set<GrantedAuthority> authorities;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/CustomUserDetailsService.java
+++ b/src/main/java/com/daily/themoti/jwt/config/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package com.daily.themoti.jwt.config;
+
+import com.daily.themoti.user.constant.UserRole;
+import com.daily.themoti.user.domain.User;
+import com.daily.themoti.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> new User(null, null, null));
+        Set<UserRole> userRole = new HashSet<>();
+        userRole.add(user.getRole());
+        return new CustomUserDetails(
+                String.valueOf(user.getEmail()),
+                userRole.stream().map(role -> role.getKey())
+                        .map(SimpleGrantedAuthority::new).collect(Collectors.toSet())
+        );
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daily/themoti/jwt/config/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.daily.themoti.jwt.config;
+
+import com.daily.themoti.jwt.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final TokenService tokenService;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = extractToken(request);
+        if (validateToken(token)) {
+            setAuthentication(token);
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String extractToken(ServletRequest request) {
+        return ((HttpServletRequest) request).getHeader("Authorization");
+    }
+
+    private boolean validateToken(String token) {
+        return token != null && tokenService.validateAccessToken(token);
+    }
+
+    private void setAuthentication(String token) {
+        String userId = tokenService.extractAccessTokenSubject(token);
+        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(userId);
+        SecurityContextHolder.getContext().setAuthentication(new CustomAuthenticationToken(userDetails, userDetails.getAuthorities()));
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/daily/themoti/jwt/config/JwtAuthenticationFilter.java
@@ -38,8 +38,8 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     }
 
     private void setAuthentication(String token) {
-        String userId = tokenService.extractAccessTokenSubject(token);
-        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(userId);
+        String email = tokenService.extractAccessTokenSubject(token);
+        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(email);
         SecurityContextHolder.getContext().setAuthentication(new CustomAuthenticationToken(userDetails, userDetails.getAuthorities()));
     }
 }

--- a/src/main/java/com/daily/themoti/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/daily/themoti/jwt/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.daily.themoti.jwt.config;
+
+import com.daily.themoti.jwt.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final TokenService tokenService;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        super.configure(web);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .httpBasic().disable()
+                .formLogin().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers(HttpMethod.GET, "/login/**", "/user/kakao/oauth").permitAll()
+                .antMatchers(HttpMethod.POST, "/refresh").permitAll()
+                .and()
+                .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())
+                .and()
+                .exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(tokenService, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/daily/themoti/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/daily/themoti/jwt/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.GET, "/login/**", "/user/kakao/oauth").permitAll()
                 .antMatchers(HttpMethod.POST, "/refresh").permitAll()
+                .antMatchers("/api/userinfo").authenticated()
                 .and()
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())
                 .and()

--- a/src/main/java/com/daily/themoti/user/constant/UserConstant.java
+++ b/src/main/java/com/daily/themoti/user/constant/UserConstant.java
@@ -1,0 +1,7 @@
+package com.daily.themoti.user.constant;
+
+public class UserConstant {
+
+    public static final String USER_NOT_EXIST = "User not exists";
+    public static final String UNAUTHORIZED = "User not authorized";
+}

--- a/src/main/java/com/daily/themoti/user/controller/UserController.java
+++ b/src/main/java/com/daily/themoti/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.daily.themoti.user.controller;
 import com.daily.themoti.global.api.ApiResponse;
 import com.daily.themoti.user.dto.LoginResponse;
 import com.daily.themoti.user.dto.RefreshTokenResponse;
+import com.daily.themoti.user.dto.UserResponseDto;
 import com.daily.themoti.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,9 +15,14 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/login/{token}")
+    @GetMapping("/api/login/{token}")
     public ApiResponse<LoginResponse> login(@PathVariable String token){
         return ApiResponse.success(HttpStatus.OK, userService.loginWithAccessToken(token));
+    }
+
+    @GetMapping("/api/userinfo")
+    public ApiResponse<UserResponseDto> getUserInfo(){
+        return ApiResponse.success(HttpStatus.OK, userService.getUserInfo());
     }
 
     @GetMapping("/user/kakao/oauth")
@@ -25,7 +31,7 @@ public class UserController {
     }
 
     @PostMapping("/refresh")
-    public ApiResponse<RefreshTokenResponse> refreshToken(@RequestHeader(value = "Authrization") String refreshToken){
+    public ApiResponse<RefreshTokenResponse> refreshToken(@RequestHeader(value = "Authorization") String refreshToken){
         return ApiResponse.success(HttpStatus.OK, userService.refreshToken(refreshToken));
     }
 }

--- a/src/main/java/com/daily/themoti/user/controller/UserController.java
+++ b/src/main/java/com/daily/themoti/user/controller/UserController.java
@@ -1,7 +1,11 @@
 package com.daily.themoti.user.controller;
 
+import com.daily.themoti.global.api.ApiResponse;
+import com.daily.themoti.user.dto.LoginResponse;
+import com.daily.themoti.user.dto.RefreshTokenResponse;
 import com.daily.themoti.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -11,12 +15,17 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/login/{token}")
-    public void login(@PathVariable String token){
-        userService.loginWithAccessToken(token);
+    public ApiResponse<LoginResponse> login(@PathVariable String token){
+        return ApiResponse.success(HttpStatus.OK, userService.loginWithAccessToken(token));
     }
 
     @GetMapping("/user/kakao/oauth")
     public String getCode(@RequestParam String code){
         return userService.getAccessToken(code);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<RefreshTokenResponse> refreshToken(@RequestHeader(value = "Authrization") String refreshToken){
+        return ApiResponse.success(HttpStatus.OK, userService.refreshToken(refreshToken));
     }
 }

--- a/src/main/java/com/daily/themoti/user/dto/LoginResponse.java
+++ b/src/main/java/com/daily/themoti/user/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.daily.themoti.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/daily/themoti/user/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/daily/themoti/user/dto/RefreshTokenResponse.java
@@ -1,0 +1,10 @@
+package com.daily.themoti.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/daily/themoti/user/dto/UserResponseDto.java
+++ b/src/main/java/com/daily/themoti/user/dto/UserResponseDto.java
@@ -1,0 +1,20 @@
+package com.daily.themoti.user.dto;
+
+import com.daily.themoti.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResponseDto {
+
+    Long id;
+    String email;
+    String username;
+
+    public UserResponseDto(User user){
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.username = user.getUsername();
+    }
+}

--- a/src/main/java/com/daily/themoti/user/exception/AuthenticationEntryPointException.java
+++ b/src/main/java/com/daily/themoti/user/exception/AuthenticationEntryPointException.java
@@ -1,0 +1,8 @@
+package com.daily.themoti.user.exception;
+
+public class AuthenticationEntryPointException extends RuntimeException {
+
+    public AuthenticationEntryPointException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/daily/themoti/user/exception/UnauthorizedUserException.java
+++ b/src/main/java/com/daily/themoti/user/exception/UnauthorizedUserException.java
@@ -1,0 +1,8 @@
+package com.daily.themoti.user.exception;
+
+public class UnauthorizedUserException extends RuntimeException {
+
+    public UnauthorizedUserException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/daily/themoti/user/exception/UserNotExistException.java
+++ b/src/main/java/com/daily/themoti/user/exception/UserNotExistException.java
@@ -1,0 +1,10 @@
+package com.daily.themoti.user.exception;
+
+public class UserNotExistException extends RuntimeException {
+
+    private static final String message = "존재하지 않는 유저입니다.";
+
+    public UserNotExistException(){
+        super(message);
+    }
+}

--- a/src/main/java/com/daily/themoti/user/service/UserService.java
+++ b/src/main/java/com/daily/themoti/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.daily.themoti.user.service;
 
 import com.daily.themoti.user.dto.LoginResponse;
 import com.daily.themoti.user.dto.RefreshTokenResponse;
+import com.daily.themoti.user.dto.UserResponseDto;
 
 public interface UserService {
 
@@ -10,4 +11,6 @@ public interface UserService {
     String getAccessToken(String code);
 
     RefreshTokenResponse refreshToken(String rToken);
+
+    UserResponseDto getUserInfo();
 }

--- a/src/main/java/com/daily/themoti/user/service/UserService.java
+++ b/src/main/java/com/daily/themoti/user/service/UserService.java
@@ -1,9 +1,13 @@
 package com.daily.themoti.user.service;
 
+import com.daily.themoti.user.dto.LoginResponse;
+import com.daily.themoti.user.dto.RefreshTokenResponse;
+
 public interface UserService {
 
-    void loginWithAccessToken(String token);
+    LoginResponse loginWithAccessToken(String token);
 
     String getAccessToken(String code);
-}
 
+    RefreshTokenResponse refreshToken(String rToken);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.datasource.password=1234
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.use-new-id-generator-mappings = false
 
 spring.profiles.include=apikey
 spring.profiles.active=local


### PR DESCRIPTION
- 카카오 access token 으로 소셜 로그인 후, jwt access token, refresh token 발급
- refresh 통한 access token 갱신
- 현재 로그인된 사용자의 userinfo 를 가져오는 기능 추가 
- 요청한 user id 값의 본인이 맞는지에 대해 확인 하는 기능 추가
- hibernate id 생성전략 옵션 수정 -> false